### PR TITLE
Fix issue with importing sessions and cache resetting

### DIFF
--- a/.changeset/serious-impalas-exist.md
+++ b/.changeset/serious-impalas-exist.md
@@ -1,0 +1,6 @@
+---
+"@quiltt/react": patch
+"@quiltt/core": patch
+---
+
+Fix issue with importing sessions and cache resetting causing request cancelations during race conditions

--- a/ECMAScript/react/src/providers/QuilttAuthProvider.tsx
+++ b/ECMAScript/react/src/providers/QuilttAuthProvider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { FC, PropsWithChildren } from 'react'
-import { useEffect, Fragment } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 
 import { useQuilttSession } from '../hooks'
 
@@ -9,14 +9,31 @@ type QuilttAuthProviderProps = PropsWithChildren & {
   token?: string
 }
 
+/**
+ * If a token is provided, will validate the token against the api and then import
+ * it into trusted storage. While this process is happening, the component is put
+ * into a loading state and the children are not rendered to prevent race conditions
+ * from triggering within the transitionary state.
+ *
+ * TODO: Consider accepting a loading component.
+ */
 export const QuilttAuthProvider: FC<QuilttAuthProviderProps> = ({ token, children }) => {
-  const { importSession } = useQuilttSession()
+  const { session, importSession } = useQuilttSession()
+  const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
-    if (importSession && token) {
+    if (session?.token == token) {
+      if (isLoading) setIsLoading(false)
+      return
+    }
+
+    if (token && !isLoading) {
+      setIsLoading(true)
       importSession(token)
     }
-  }, [importSession, token])
+  }, [session?.token, token, isLoading, setIsLoading, importSession])
+
+  if (isLoading) return null
 
   return <Fragment>{children}</Fragment>
 }


### PR DESCRIPTION
Fix issue with importing sessions and cache resetting causing request cancelations during race conditions