### PR TITLE
Remove RN about:srcdoc warning

### DIFF
--- a/.changeset/pink-horses-thank.md
+++ b/.changeset/pink-horses-thank.md
@@ -1,0 +1,8 @@
+---
+"@quiltt/react-native": patch
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/examples-nextjs": patch
+---
+
+Remove React Native SDK about:srcdoc warning

--- a/packages/react-native/src/components/QuilttConnector.tsx
+++ b/packages/react-native/src/components/QuilttConnector.tsx
@@ -167,7 +167,6 @@ const QuilttConnector = ({
       console.log(`handleOAuthUrl - Skipping non https url - ${oauthUrl.href}`)
       return
     }
-    console.log('handleOAuthUrl', oauthUrl)
     Linking.openURL(oauthUrl.href)
   }, [])
 
@@ -229,7 +228,6 @@ const QuilttConnector = ({
   const requestHandler = useCallback(
     (request: ShouldStartLoadRequest) => {
       const url = new URL(request.url)
-      console.log('requestHandler', url)
 
       if (isQuilttEvent(url)) {
         handleQuilttEvent(url)

--- a/packages/react-native/src/components/QuilttConnector.tsx
+++ b/packages/react-native/src/components/QuilttConnector.tsx
@@ -150,8 +150,6 @@ const QuilttConnector = ({
     (url: URL) => {
       if (isQuilttEvent(url)) return false
       if (url.protocol !== 'https:') {
-        const err = new Error(`Invalid url leaked ${url.href}`)
-        errorReporter.send(err)
         return false
       }
       return allowedListUrl.some((href) => url.href.includes(href))
@@ -169,6 +167,7 @@ const QuilttConnector = ({
       console.log(`handleOAuthUrl - Skipping non https url - ${oauthUrl.href}`)
       return
     }
+    console.log('handleOAuthUrl', oauthUrl)
     Linking.openURL(oauthUrl.href)
   }, [])
 
@@ -230,6 +229,7 @@ const QuilttConnector = ({
   const requestHandler = useCallback(
     (request: ShouldStartLoadRequest) => {
       const url = new URL(request.url)
+      console.log('requestHandler', url)
 
       if (isQuilttEvent(url)) {
         handleQuilttEvent(url)
@@ -252,7 +252,9 @@ const QuilttConnector = ({
     <AndroidSafeAreaView>
       <WebView
         ref={webViewRef}
-        originWhitelist={['https://*', 'quilttconnector://*']} // Guard against other non SDK needed url
+        // Plaid keep sending window.location = 'about:srcdoc' and causes some noise in RN
+        // All whitelists are now handled in requestHandler, handleQuilttEvent and handleOAuthUrl
+        originWhitelist={['*']}
         source={{ uri: connectorUrl }}
         onShouldStartLoadWithRequest={requestHandler}
         javaScriptEnabled


### PR DESCRIPTION
Plaid for some reason, will attempt to set window.location = about:srcdoc
The way I used to filter it seems to produce a warning
So I just let existing requestHandler, handleQuilttEvent and handleOAuthUrl to handle.

Also remove an unnecessary HB reporting
