### PR TITLE
Improve typeof checks for mobile environments

### DIFF
--- a/.changeset/clever-boxes-float.md
+++ b/.changeset/clever-boxes-float.md
@@ -1,0 +1,7 @@
+---
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-native": patch
+---
+
+Improve typeof checks for mobile environments

--- a/packages/core/src/storage/Local.ts
+++ b/packages/core/src/storage/Local.ts
@@ -11,7 +11,7 @@ export class LocalStorage<T> {
   private observers: { [key: string]: Observer<T>[] } = {}
 
   constructor() {
-    if (typeof window !== 'undefined' && !window?.expo) {
+    if (typeof window !== 'undefined' && typeof window.addEventListener !== 'undefined') {
       window.addEventListener('storage', this.handleStorageEvent.bind(this))
     }
   }
@@ -29,7 +29,7 @@ export class LocalStorage<T> {
   isDisabled = (): boolean => !this.isEnabled()
 
   get = (key: string): Maybe<T> | undefined => {
-    if (typeof window === 'undefined' || !!window.expo) return undefined
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') return undefined
 
     try {
       const state = window.localStorage.getItem(`quiltt.${key}`)
@@ -41,7 +41,7 @@ export class LocalStorage<T> {
   }
 
   set = (key: string, state: Maybe<T> | undefined): void => {
-    if (typeof window === 'undefined' || !!window.expo) return
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') return
 
     try {
       if (state) {
@@ -55,6 +55,8 @@ export class LocalStorage<T> {
   }
 
   remove = (key: string) => {
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') return
+
     try {
       window.localStorage.removeItem(`quiltt.${key}`)
     } catch (error) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,8 +8,3 @@ export type Nullable<T> = { [K in keyof T]: T[K] | null }
 export type Mutable<Type> = { -readonly [Key in keyof Type]: Type[Key] }
 export type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T
 export type DeepReadonly<T> = T extends object ? { [P in keyof T]: DeepReadonly<T[P]> } : T
-declare global {
-  interface Window {
-    expo: any
-  }
-}


### PR DESCRIPTION
This replaces the expo specific check with `typeof` checks that should work in more situations.