### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Delete existing git tags for @quiltt/examples-
+        run: |
+          # Fetch all tags from the remote to ensure the local git is up-to-date
+          git fetch --tags
+          # Find tags starting with @quiltt/examples- and delete them locally and remotely
+          git tag -l "@quiltt/examples-*" | xargs -n 1 -I % sh -c 'git tag -d %; git push origin --delete %'
+
       - name: Create release pull request or release to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
This fixes the "git tag already exists" error during release. The error does not break anything with publishing for npm, only during release creation on GitHub