### PR TITLE
Fix debugging config

### DIFF
--- a/.changeset/lazy-jokes-chew.md
+++ b/.changeset/lazy-jokes-chew.md
@@ -1,0 +1,7 @@
+---
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-native": patch
+---
+
+Fix debug config during CI

--- a/biome.json
+++ b/biome.json
@@ -1,12 +1,7 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
-    "ignore": [
-      "**/*.gen.ts",
-      "**/generated/**",
-      "**/spectaql.css",
-      "**/src/components/HomeImage.tsx"
-    ]
+    "ignore": ["**/*.gen.ts", "**/generated/**"]
   },
   "organizeImports": {
     "enabled": true

--- a/packages/core/src/api/rest/auth.ts
+++ b/packages/core/src/api/rest/auth.ts
@@ -33,7 +33,7 @@ type Revoke = NoContentData | UnauthorizedData
 export type SessionResponse = FetchResponse<SessionData>
 export type UnprocessableResponse = FetchResponse<UnprocessableData>
 
-// https://www.quiltt.dev/api-reference/rest/auth#
+// https://www.quiltt.dev/api-reference/auth
 export class AuthAPI {
   clientId: string | undefined
 

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -2,12 +2,9 @@ import { name as packageName, version as packageVersion } from '../package.json'
 
 const QUILTT_API_INSECURE = (() => {
   try {
-    if (process.env.QUILTT_API_INSECURE === 'true' || process.env.QUILTT_API_INSECURE === 'false') {
-      return process.env.QUILTT_API_INSECURE === 'true'
-    }
-    return process.env.QUILTT_API_INSECURE
+    return process.env.QUILTT_API_INSECURE === 'true'
   } catch {
-    return undefined
+    return false
   }
 })()
 
@@ -21,7 +18,7 @@ const QUILTT_API_DOMAIN = (() => {
 
 const QUILTT_DEBUG = (() => {
   try {
-    return !!process.env.QUILTT_DEBUG || process.env.NODE_ENV !== 'production'
+    return process.env.NODE_ENV !== 'production' && process.env.QUILTT_DEBUG === 'true'
   } catch {
     return false
   }

--- a/packages/core/tests/api/rest/auth.test.ts
+++ b/packages/core/tests/api/rest/auth.test.ts
@@ -1,7 +1,9 @@
-import { AuthAPI, PasscodePayload, UsernamePayload } from '@/api/rest/auth'
+import { AuthAPI } from '@/api/rest/auth'
 import { fetchWithRetry } from '@/api/rest/fetchWithRetry'
 import { endpointAuth } from '@/configuration'
 import { describe, it, beforeEach, expect, vi } from 'vitest'
+
+import type { PasscodePayload, UsernamePayload } from '@/api/rest/auth'
 import type { Mock, MockInstance } from 'vitest'
 
 vi.mock('@/api/rest/fetchWithRetry', () => ({

--- a/packages/core/tests/configuration.test.ts
+++ b/packages/core/tests/configuration.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { name as packageName, version as packageVersion } from '../package.json'
 
+// Save the original environment variables
+const originalEnv = process.env
+
 // Function to load the configuration with cache busting
 const loadConfig = async (envConfig: Record<string, string | undefined>) => {
   // Set environment variables
@@ -13,35 +16,103 @@ const loadConfig = async (envConfig: Record<string, string | undefined>) => {
   return import(configModulePath)
 }
 
+// Reset the environment variables before each test
+beforeEach(() => {
+  process.env = { ...originalEnv }
+})
+
 describe('Configuration Constants', () => {
   it('should format the version correctly', async () => {
     const config = await loadConfig({})
     expect(config.version).toBe(`${packageName}: v${packageVersion}`)
   })
 
-  it('should reflect the correct debugging status based on environment', async () => {
-    const config = await loadConfig({ NODE_ENV: 'development' })
-    expect(config.debugging).toBeTruthy()
-  })
-})
+  it('should use secure protocols with quiltt.io by default', async () => {
+    const config = await loadConfig({})
 
-describe.each([
-  ['true', 'http', 'ws'],
-  ['false', 'https', 'wss'],
-])('Configuration under insecure=%s', (insecure, httpProtocol, wsProtocol) => {
-  let config: any
-
-  beforeEach(async () => {
-    config = await loadConfig({ QUILTT_API_INSECURE: insecure })
+    expect(config.cdnBase).toMatch('https://cdn.quiltt.io')
+    expect(config.endpointAuth).toMatch('https://auth.quiltt.io/v1/users/session')
+    expect(config.endpointGraphQL).toMatch('https://api.quiltt.io/v1/graphql')
+    expect(config.endpointWebsockets).toMatch('wss://api.quiltt.io/websockets')
   })
 
-  it(`should use ${httpProtocol.toUpperCase()} for CDN and endpoints`, () => {
-    expect(config.cdnBase.startsWith(`${httpProtocol}://`)).toBeTruthy()
-    expect(config.endpointAuth.startsWith(`${httpProtocol}://`)).toBeTruthy()
-    expect(config.endpointGraphQL.startsWith(`${httpProtocol}://`)).toBeTruthy()
+  // Ensure that packages work on React Native and other platforms with no process.env support
+  describe('when process.env is not available', () => {
+    beforeEach(async () => {
+      // @ts-ignore
+      // biome-ignore lint/performance/noDelete: <explanation>
+      delete process.env
+    })
+
+    it('should use secure protocols with quiltt.io', async () => {
+      const config = await loadConfig({})
+
+      expect(config.cdnBase).toBe('https://cdn.quiltt.io')
+      expect(config.endpointAuth).toBe('https://auth.quiltt.io/v1/users/session')
+      expect(config.endpointGraphQL).toBe('https://api.quiltt.io/v1/graphql')
+      expect(config.endpointWebsockets).toBe('wss://api.quiltt.io/websockets')
+    })
   })
 
-  it(`should use ${wsProtocol.toUpperCase()} for Websockets`, () => {
-    expect(config.endpointWebsockets.startsWith(`${wsProtocol}://`)).toBeTruthy()
+  describe('API Domain', () => {
+    describe.each([
+      [undefined, 'quiltt.io'],
+      ['quiltt.io', 'quiltt.io'],
+      ['lvh.me:3000', 'lvh.me:3000'],
+    ])('when QUILTT_API_DOMAIN is %s', (quilttApiDomain, expectedDomain) => {
+      it(`should use ${expectedDomain}`, async () => {
+        const config = await loadConfig({ QUILTT_API_DOMAIN: quilttApiDomain })
+
+        expect(config.cdnBase).toMatch(new RegExp(`://cdn.${expectedDomain}$`))
+        expect(config.endpointAuth).toMatch(
+          new RegExp(`://auth.${expectedDomain}/v1/users/session$`)
+        )
+        expect(config.endpointGraphQL).toMatch(new RegExp(`://api.${expectedDomain}/v1/graphql$`))
+        expect(config.endpointWebsockets).toMatch(
+          new RegExp(`://api.${expectedDomain}/websockets$`)
+        )
+      })
+    })
+  })
+
+  describe('Protocols', () => {
+    describe.each([
+      ['true', 'http', 'ws'],
+      ['false', 'https', 'wss'],
+      [undefined, 'https', 'wss'],
+    ])('Configuration when QUILTT_API_INSECURE is %s', (insecure, httpProtocol, wsProtocol) => {
+      let config: any
+
+      beforeEach(async () => {
+        config = await loadConfig({ QUILTT_API_INSECURE: insecure })
+      })
+
+      it(`should use ${httpProtocol.toUpperCase()} for CDN and endpoints`, () => {
+        expect(config.cdnBase).toMatch(new RegExp(`^${httpProtocol}://`))
+        expect(config.endpointAuth).toMatch(new RegExp(`^${httpProtocol}://`))
+        expect(config.endpointGraphQL).toMatch(new RegExp(`^${httpProtocol}://`))
+      })
+
+      it(`should use ${wsProtocol.toUpperCase()} for Websockets`, () => {
+        expect(config.endpointWebsockets).toMatch(new RegExp(`^${wsProtocol}://`))
+      })
+    })
+  })
+
+  describe('Debugging', () => {
+    describe.each([
+      ['production', 'true', false],
+      ['production', 'false', false],
+      ['production', undefined, false],
+      ['development', 'true', true],
+      ['development', 'false', false],
+      ['development', undefined, false],
+    ])('when NODE_ENV is %s and QUILTT_DEBUG is %s', (nodeEnv, quilttDebug, expectedDebugging) => {
+      it(`should be ${expectedDebugging ? 'enabled' : 'disabled'}`, async () => {
+        const config = await loadConfig({ NODE_ENV: nodeEnv, QUILTT_DEBUG: quilttDebug })
+
+        expect(config.debugging).toBe(expectedDebugging)
+      })
+    })
   })
 })


### PR DESCRIPTION
- Made the package respect `QUILTT_DEBUG=false` env var setting while running CI for apps that use `@quiltt/core`
- Made sure test running config loader handles `undefined` inputs correctly
- Added more configuration test scenarios 
