### PR TITLE
Migrate Apollo client to deep entrypoint imports

### DIFF
--- a/packages/core/src/api/graphql/client.ts
+++ b/packages/core/src/api/graphql/client.ts
@@ -1,5 +1,5 @@
-import type { ApolloClientOptions, Operation } from '@apollo/client/index.js'
-import { ApolloClient, ApolloLink } from '@apollo/client/index.js'
+import type { ApolloClientOptions, Operation } from '@apollo/client/core'
+import { ApolloClient, ApolloLink } from '@apollo/client/core'
 
 import { debugging } from '../../configuration'
 import {
@@ -44,9 +44,17 @@ export class QuilttClient<T> extends ApolloClient<T> {
   }
 }
 
-export { InMemoryCache, gql, useMutation, useQuery, useSubscription } from '@apollo/client/index.js'
-export type {
-  NormalizedCacheObject,
-  OperationVariables,
-  ApolloError,
-} from '@apollo/client/index.js'
+/**
+/* Export Apollo GraphQL assets using deep-imports to prevent unnecessary imports
+/* and make tree-shaking more effective
+*/
+
+/** Client and Tooling */
+export { gql } from '@apollo/client/core'
+export { InMemoryCache } from '@apollo/client/cache'
+export type { ApolloError, OperationVariables } from '@apollo/client/core'
+export type { NormalizedCacheObject } from '@apollo/client/cache'
+
+/** React Hooks */
+// @todo: consider exporting these from @quiltt/react instead
+export { useMutation, useQuery, useSubscription } from '@apollo/client/react/hooks'

--- a/packages/core/src/api/graphql/links/ActionCableLink.ts
+++ b/packages/core/src/api/graphql/links/ActionCableLink.ts
@@ -1,5 +1,7 @@
-import type { FetchResult, NextLink, Operation } from '@apollo/client/core/index.js'
-import { ApolloLink, Observable } from '@apollo/client/core/index.js'
+import { ApolloLink } from '@apollo/client/core'
+import { Observable } from '@apollo/client/utilities'
+import type { FetchResult, NextLink, Operation } from '@apollo/client/core'
+
 import { createConsumer } from '@rails/actioncable'
 import type { Consumer } from '@rails/actioncable'
 import { print } from 'graphql'

--- a/packages/core/src/api/graphql/links/AuthLink.ts
+++ b/packages/core/src/api/graphql/links/AuthLink.ts
@@ -1,5 +1,6 @@
-import type { FetchResult, NextLink, Observable, Operation } from '@apollo/client/index.js'
-import { ApolloLink } from '@apollo/client/index.js'
+import { ApolloLink } from '@apollo/client/core'
+import type { FetchResult, NextLink, Operation } from '@apollo/client/core'
+import type { Observable } from '@apollo/client/utilities'
 
 import { GlobalStorage } from '@/storage'
 

--- a/packages/core/src/api/graphql/links/BatchHttpLink.ts
+++ b/packages/core/src/api/graphql/links/BatchHttpLink.ts
@@ -1,4 +1,4 @@
-import { BatchHttpLink as ApolloHttpLink } from '@apollo/client/link/batch-http/index.js'
+import { BatchHttpLink as ApolloHttpLink } from '@apollo/client/link/batch-http'
 import crossfetch from 'cross-fetch'
 
 import { endpointGraphQL } from '@/configuration'

--- a/packages/core/src/api/graphql/links/ErrorLink.ts
+++ b/packages/core/src/api/graphql/links/ErrorLink.ts
@@ -1,7 +1,7 @@
 import { GlobalStorage } from '@/storage'
 
-import type { ServerError } from '@apollo/client/index.js'
-import { onError } from '@apollo/client/link/error/index.js'
+import type { ServerError } from '@apollo/client/core'
+import { onError } from '@apollo/client/link/error'
 
 export const ErrorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors) {

--- a/packages/core/src/api/graphql/links/ForwardableLink.ts
+++ b/packages/core/src/api/graphql/links/ForwardableLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink } from '@apollo/client/index.js'
+import { ApolloLink } from '@apollo/client/core'
 
 export const ForwardableLink = new ApolloLink((operation, forward) => forward(operation))
 

--- a/packages/core/src/api/graphql/links/HttpLink.ts
+++ b/packages/core/src/api/graphql/links/HttpLink.ts
@@ -1,4 +1,4 @@
-import { HttpLink as ApolloHttpLink } from '@apollo/client/link/http/index.js'
+import { HttpLink as ApolloHttpLink } from '@apollo/client/link/http'
 import crossfetch from 'cross-fetch'
 
 // Use `cross-fetch` only if `fetch` is not available on the `globalThis` object

--- a/packages/core/src/api/graphql/links/RetryLink.ts
+++ b/packages/core/src/api/graphql/links/RetryLink.ts
@@ -1,4 +1,4 @@
-import { RetryLink as ApolloRetryLink } from '@apollo/client/link/retry/index.js'
+import { RetryLink as ApolloRetryLink } from '@apollo/client/link/retry'
 
 export const RetryLink = new ApolloRetryLink({
   attempts: {

--- a/packages/core/src/api/graphql/links/TerminatingLink.ts
+++ b/packages/core/src/api/graphql/links/TerminatingLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink } from '@apollo/client/index.js'
+import { ApolloLink } from '@apollo/client/core'
 
 export const TerminatingLink = new ApolloLink(() => null)
 

--- a/packages/core/src/api/graphql/links/VersionLink.ts
+++ b/packages/core/src/api/graphql/links/VersionLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink } from '@apollo/client/index.js'
+import { ApolloLink } from '@apollo/client/core'
 
 import { version } from '@/configuration'
 

--- a/packages/react/src/hooks/useQuilttClient.ts
+++ b/packages/react/src/hooks/useQuilttClient.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useApolloClient } from '@apollo/client/index.js'
+import { useApolloClient } from '@apollo/client/react/hooks'
 
 export const useQuilttClient = useApolloClient
 

--- a/packages/react/src/providers/QuilttAuthProvider.tsx
+++ b/packages/react/src/providers/QuilttAuthProvider.tsx
@@ -4,7 +4,9 @@ import type { FC, PropsWithChildren } from 'react'
 import { useEffect, useMemo } from 'react'
 
 import { ApolloProvider } from '@apollo/client'
+
 import { InMemoryCache, QuilttClient } from '@quiltt/core'
+
 import { useQuilttSession } from '../hooks'
 
 type QuilttAuthProviderProps = PropsWithChildren & {


### PR DESCRIPTION
This significantly reduces the size of the unminified React package by using Apollo Client's deep entrypoint import approach.  

See: https://www.apollographql.com/docs/react/development-testing/reducing-bundle-size#picking-an-import-style