### PR TITLE
Fix VersionLink to allow custom Quiltt-SDK-Agent header override

### DIFF
--- a/.changeset/fancy-news-relate.md
+++ b/.changeset/fancy-news-relate.md
@@ -1,0 +1,7 @@
+---
+"@quiltt/core": patch
+"@quiltt/react": patch
+"@quiltt/react-native": patch
+---
+
+Fix VersionLink to allow custom Quiltt-SDK-Agent header override

--- a/packages/core/src/api/graphql/links/VersionLink.ts
+++ b/packages/core/src/api/graphql/links/VersionLink.ts
@@ -10,9 +10,9 @@ export const createVersionLink = (platformInfo: string) => {
   return new ApolloLink((operation, forward) => {
     operation.setContext(({ headers = {} }) => ({
       headers: {
-        ...headers,
         'Quiltt-Client-Version': version,
         'Quiltt-SDK-Agent': sdkAgent,
+        ...headers,
       },
     }))
     return forward(operation)


### PR DESCRIPTION
## Summary

<!--- CHANGELOG_START -->
## Bug Fixes <!--- Delete section if not needed -->
- Fix VersionLink to allow custom Quiltt-SDK-Agent header override

<!--- CHANGELOG_END -->

## Release Checklist

- [x] **Is commit history clean?**
  - Do all commit names start with verbs like `Add`, `Fix`, `Refactor`...?
  - Are all commits passing or marked with `[WIP]`?
- [x] **Are relevant documentation changes queued up?**
  - Are the Quiltt API Docs updated?
