### PR TITLE
[Vue] Feature Parity with React Package

### DIFF
--- a/.changeset/ripe-animals-punch.md
+++ b/.changeset/ripe-animals-punch.md
@@ -1,0 +1,19 @@
+---
+"@quiltt/flutter": patch
+"@quiltt/vue": patch
+"@quiltt/android": patch
+"@quiltt/capacitor": patch
+"@quiltt/core": patch
+"@quiltt/ios": patch
+"@quiltt/react": patch
+"@quiltt/react-native": patch
+---
+
+## Vue: Add feature parity with React package
+
+- **New `QuilttContainer` component** — renders the connector inline, matching the React package API. Deprecates `QuilttConnector` in favor of this component.
+- **New `useQuilttConnector` composable** — provides SDK loading, connector lifecycle management, and session-based authentication outside of components.
+- **`QuilttButton` enhancements** — added `@click` event passthrough with `event.preventDefault()` support, `forceRemountOnConnectionChange` prop, and `quiltt-connection` / `quiltt-app-launcher-uri` attributes.
+- **Additional connector events** — added `@open`, `@exit`, and `@event` emits to `QuilttButton` and `QuilttContainer`.
+- **Force remount mechanism** — new `forceRemountOnConnectionChange` prop on `QuilttButton`, `QuilttContainer`, and `QuilttConnector` forces a complete remount when `connectionId` changes, useful for ensuring clean connector state.
+- **Deprecation check workflow** — CI check that validates deprecated component usage (`.github/actions/check-deprecations`).

--- a/.github/actions/check-deprecations/action.yml
+++ b/.github/actions/check-deprecations/action.yml
@@ -1,0 +1,16 @@
+name: "Check Deprecations Before Major Bump"
+description: "Fails when a PR includes a major changeset but leftover @deprecated code still exists"
+
+inputs:
+  working-directory:
+    description: "Monorepo root directory"
+    required: false
+    default: "."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check for leftover deprecations against major changesets
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: node scripts/check-deprecations.mjs

--- a/.github/workflows/check-deprecations.yml
+++ b/.github/workflows/check-deprecations.yml
@@ -1,0 +1,26 @@
+name: Check Deprecations
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - ".changeset/**"
+      - "packages/*/src/**"
+
+permissions:
+  contents: read
+
+jobs:
+  check-deprecations:
+    name: Deprecation Audit (Major Bump)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js Environment
+        uses: ./.github/actions/setup-js
+        with:
+          build-packages: "false"
+
+      - name: Audit Deprecations
+        uses: ./.github/actions/check-deprecations

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:packages": "turbo run build --filter='./packages/*'",
     "bundlesize": "size-limit",
     "changeset": "npx changeset",
+    "check:deprecations": "node scripts/check-deprecations.mjs",
     "check:packages": "pnpm check-dependency-version-consistency .",
     "clean": "turbo run clean",
     "dev": "turbo run dev --parallel",

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -197,7 +197,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.2.4"
+    version: "5.2.5"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -61,12 +61,27 @@ import { QuilttButton } from '@quiltt/vue/components'
 
 ### QuilttButton
 
-Opens the connector in a modal overlay.
+Opens the connector in a modal overlay. Supports custom click handlers via `@click` event.
 
 ```vue
-<QuilttButton connector-id="YOUR_CONNECTOR_ID" @exit-success="handleSuccess">
+<QuilttButton 
+  connector-id="YOUR_CONNECTOR_ID" 
+  @click="handleClick"
+  @exit-success="handleSuccess"
+>
   Connect Account
 </QuilttButton>
+```
+
+To prevent the connector from opening, call `event.preventDefault()` in your click handler:
+
+```typescript
+const handleClick = (event: MouseEvent) => {
+  // Perform validation
+  if (!isReady) {
+    event.preventDefault() // Prevents connector from opening
+  }
+}
 ```
 
 ### QuilttContainer
@@ -78,6 +93,8 @@ Renders the connector inline.
 ```
 
 ### QuilttConnector
+
+⚠️ **Deprecated** — Use [`QuilttContainer`](#quilttcontainer) instead. It provides the same inline connector experience and aligns with the React package API.
 
 Full-page iframe for embedded integration.
 
@@ -131,6 +148,20 @@ const { open } = useQuilttConnector('YOUR_CONNECTOR_ID', {
 <button @click="open">Add Account</button>
 ```
 
+**Best Practice:** Memoize callback functions to avoid warnings and prevent unexpected behavior:
+
+```typescript
+import { computed } from 'vue'
+
+const handleExitSuccess = computed(() => (m) => {
+  console.log('Connected:', m.connectionId)
+})
+
+const { open } = useQuilttConnector('YOUR_CONNECTOR_ID', {
+  onExitSuccess: handleExitSuccess.value,
+})
+```
+
 ### Additional Composables
 
 `@quiltt/vue` also exports:
@@ -157,19 +188,23 @@ import { QuilttPlugin, QuilttSessionKey, QuilttSetSessionKey } from '@quiltt/vue
 
 ## Props and Events
 
-| Prop | Type | Description |
-| ------ | ------ | ------------- |
-| `connector-id` | `string` | **Required.** Quiltt Connector ID |
-| `connection-id` | `string` | Existing connection ID for reconnection |
-| `institution` | `string` | Pre-select an institution |
-| `app-launcher-url` | `string` | Deep link URL for OAuth callbacks |
+| Prop | Type | Default | Description |
+| ------ | ------ | ------ | ------------- |
+| `connector-id` | `string` | — | **Required.** Quiltt Connector ID |
+| `connection-id` | `string` | — | Existing connection ID for reconnection |
+| `institution` | `string` | — | Pre-select an institution |
+| `app-launcher-url` | `string` | — | Deep link URL for OAuth callbacks |
+| `force-remount-on-connection-change` | `boolean` | `false` | Force complete remount when `connectionId` changes (useful as fallback for clean state) |
 
 | Event | Payload | Description |
 | ------- | --------- | ------------- |
 | `@load` | `metadata` | Connector loaded |
+| `@open` | `metadata` | Connector opened (modal/inline) |
+| `@exit` | `type, metadata` | Connector exited (any reason) |
 | `@exit-success` | `metadata` | Connection successful |
 | `@exit-abort` | `metadata` | User cancelled |
 | `@exit-error` | `metadata` | Error occurred |
+| `@event` | `type, metadata` | Any connector event |
 
 ## Reconnection
 
@@ -177,6 +212,16 @@ Pass `connection-id` to reconnect an existing connection:
 
 ```vue
 <QuilttButton connection-id="YOUR_EXISTING_CONNECTION_ID" ... />
+```
+
+When `connection-id` changes, the component automatically updates the existing connector instance with the new connection details. To force a complete remount instead, use `force-remount-on-connection-change`:
+
+```vue
+<QuilttButton 
+  connection-id="YOUR_EXISTING_CONNECTION_ID"
+  force-remount-on-connection-change
+  ...
+/>
 ```
 
 ## Capacitor / Ionic

--- a/packages/vue/src/components/QuilttButton.ts
+++ b/packages/vue/src/components/QuilttButton.ts
@@ -4,6 +4,10 @@
  * Wraps a button (or custom element) that opens the Quiltt Connector
  * in a modal overlay when clicked.
  *
+ * When connectionId changes, the button will automatically update the existing
+ * connector instance with the new connection details. If you need to force a
+ * complete remount instead, set forceRemountOnConnectionChange to true.
+ *
  * @example
  * ```vue
  * <QuilttButton
@@ -58,6 +62,15 @@ export const QuilttButton = defineComponent({
     as: {
       type: String,
       default: 'button',
+    },
+    /**
+     * Forces complete remount when connectionId changes.
+     * Useful as a fallback for ensuring clean state.
+     * @default false
+     */
+    forceRemountOnConnectionChange: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -126,16 +139,36 @@ export const QuilttButton = defineComponent({
         : undefined,
     })
 
-    const handleClick = () => {
-      open()
+    const handleClick = (event: MouseEvent) => {
+      // Call the user's onClick handler if provided
+      const userOnClick = vProps?.onClick
+      if (userOnClick) {
+        userOnClick(event)
+      }
+
+      // Only open if event wasn't prevented
+      if (!event.defaultPrevented) {
+        open()
+      }
     }
+
+    // Generate key for forced remounting if enabled, but respect user-provided key
+    const componentKey = computed(() => {
+      if (!props.forceRemountOnConnectionChange) {
+        return undefined
+      }
+      return `${props.connectorId}-${props.connectionId || 'no-connection'}`
+    })
 
     return () =>
       h(
         props.as,
         {
+          key: componentKey.value,
           class: 'quiltt-button',
           onClick: handleClick,
+          'quiltt-connection': props.connectionId,
+          'quiltt-app-launcher-uri': effectiveAppLauncherUri.value,
         },
         slots.default?.()
       )

--- a/packages/vue/src/components/QuilttConnector.ts
+++ b/packages/vue/src/components/QuilttConnector.ts
@@ -1,12 +1,16 @@
 /**
  * QuilttConnector - Embeds the Quiltt Connector in an iframe
  *
+ * @deprecated Use {@link QuilttContainer} instead. This component will be
+ * removed in a future version. `QuilttContainer` provides the same inline
+ * connector experience and aligns with the React package API.
+ *
  * This component renders the Quiltt Connector directly in your page,
  * suitable for full-page or embedded connector experiences.
  *
  * @example
  * ```vue
- * <QuilttConnector
+ * <QuilttContainer
  *   :connector-id="connectorId"
  *   @exit-success="handleSuccess"
  * />
@@ -48,6 +52,15 @@ export const QuilttConnector = defineComponent({
       type: String as PropType<string | undefined>,
       default: undefined,
     },
+    /**
+     * Forces complete remount when connectionId changes.
+     * Useful as a fallback for ensuring clean state.
+     * @default false
+     */
+    forceRemountOnConnectionChange: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: {
@@ -66,6 +79,11 @@ export const QuilttConnector = defineComponent({
   },
 
   setup(props, { emit, expose }) {
+    console.warn(
+      '[Quiltt] QuilttConnector is deprecated. Use QuilttContainer instead, which provides ' +
+        'the same inline connector experience and aligns with the @quiltt/react package API.'
+    )
+
     const iframeRef = ref<HTMLIFrameElement>()
     const { session } = useQuilttSession()
 
@@ -191,6 +209,14 @@ export const QuilttConnector = defineComponent({
 
     expose({ handleOAuthCallback })
 
+    // Generate key for forced remounting if enabled
+    const componentKey = computed(() => {
+      if (!props.forceRemountOnConnectionChange) {
+        return undefined
+      }
+      return `${props.connectorId}-${props.connectionId || 'no-connection'}`
+    })
+
     onMounted(() => {
       window.addEventListener('message', handleMessage)
     })
@@ -201,6 +227,7 @@ export const QuilttConnector = defineComponent({
 
     return () =>
       h('iframe', {
+        key: componentKey.value,
         ref: iframeRef,
         src: connectorUrl.value,
         allow: 'publickey-credentials-get *',

--- a/packages/vue/src/components/QuilttConnector.ts
+++ b/packages/vue/src/components/QuilttConnector.ts
@@ -24,6 +24,8 @@ import type { ConnectorSDKCallbackMetadata, ConnectorSDKEventType } from '@quilt
 
 import { useQuilttSession } from '../composables/useQuilttSession'
 
+let deprecationWarned = false
+
 export interface QuilttConnectorHandle {
   handleOAuthCallback: (url: string) => void
 }
@@ -79,10 +81,13 @@ export const QuilttConnector = defineComponent({
   },
 
   setup(props, { emit, expose }) {
-    console.warn(
-      '[Quiltt] QuilttConnector is deprecated. Use QuilttContainer instead, which provides ' +
-        'the same inline connector experience and aligns with the @quiltt/react package API.'
-    )
+    if (!deprecationWarned) {
+      deprecationWarned = true
+      console.warn(
+        '[Quiltt] QuilttConnector is deprecated. Use QuilttContainer instead, which provides ' +
+          'the same inline connector experience and aligns with the @quiltt/react package API.'
+      )
+    }
 
     const iframeRef = ref<HTMLIFrameElement>()
     const { session } = useQuilttSession()

--- a/packages/vue/src/components/QuilttContainer.ts
+++ b/packages/vue/src/components/QuilttContainer.ts
@@ -5,6 +5,10 @@
  * The SDK detects the `quiltt-container` attribute and renders the connector
  * inline automatically — no manual `open()` call required.
  *
+ * When connectionId changes, the container will automatically update the existing
+ * connector instance with the new connection details. If you need to force a
+ * complete remount instead, set forceRemountOnConnectionChange to true.
+ *
  * @example
  * ```vue
  * <QuilttContainer
@@ -58,11 +62,22 @@ export const QuilttContainer = defineComponent({
       type: String,
       default: 'div',
     },
+    /**
+     * Forces complete remount when connectionId changes.
+     * Useful as a fallback for ensuring clean state.
+     * @default false
+     */
+    forceRemountOnConnectionChange: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: {
     /** Connector loaded */
     load: (_metadata: ConnectorSDKCallbackMetadata) => true,
+    /** Connector opened */
+    open: (_metadata: ConnectorSDKCallbackMetadata) => true,
     /** Connection successful */
     'exit-success': (_metadata: ConnectorSDKCallbackMetadata) => true,
     /** User cancelled */
@@ -102,6 +117,9 @@ export const QuilttContainer = defineComponent({
         ? (type: ConnectorSDKEventType, metadata: ConnectorSDKCallbackMetadata) =>
             emit('event', type, metadata)
         : undefined,
+      onOpen: vProps?.onOpen
+        ? (metadata: ConnectorSDKCallbackMetadata) => emit('open', metadata)
+        : undefined,
       onLoad: vProps?.onLoad
         ? (metadata: ConnectorSDKCallbackMetadata) => emit('load', metadata)
         : undefined,
@@ -120,10 +138,19 @@ export const QuilttContainer = defineComponent({
         : undefined,
     })
 
+    // Generate key for forced remounting if enabled, but respect user-provided key
+    const componentKey = computed(() => {
+      if (!props.forceRemountOnConnectionChange) {
+        return undefined
+      }
+      return `${props.connectorId}-${props.connectionId || 'no-connection'}`
+    })
+
     return () =>
       h(
         props.as,
         {
+          key: componentKey.value,
           'quiltt-container': props.connectorId,
           'quiltt-connection': props.connectionId,
           'quiltt-app-launcher-uri': effectiveAppLauncherUri.value,

--- a/packages/vue/src/composables/useQuilttConnector.ts
+++ b/packages/vue/src/composables/useQuilttConnector.ts
@@ -184,6 +184,54 @@ export const useQuilttConnector = (
     { immediate: true }
   )
 
+  // Track callback changes to warn about potential memory leaks
+  let prevCallbacks = {
+    onEvent: options?.onEvent,
+    onOpen: options?.onOpen,
+    onLoad: options?.onLoad,
+    onExit: options?.onExit,
+    onExitSuccess: options?.onExitSuccess,
+    onExitAbort: options?.onExitAbort,
+    onExitError: options?.onExitError,
+  }
+  let hasConnectorBeenCreated = false
+
+  watch(
+    () => ({
+      onEvent: options?.onEvent,
+      onOpen: options?.onOpen,
+      onLoad: options?.onLoad,
+      onExit: options?.onExit,
+      onExitSuccess: options?.onExitSuccess,
+      onExitAbort: options?.onExitAbort,
+      onExitError: options?.onExitError,
+    }),
+    (newCallbacks) => {
+      // Skip warning on initial setup
+      if (!hasConnectorBeenCreated) return
+
+      // Check if callbacks actually changed by comparing object references
+      const callbacksChanged =
+        prevCallbacks.onEvent !== newCallbacks.onEvent ||
+        prevCallbacks.onOpen !== newCallbacks.onOpen ||
+        prevCallbacks.onLoad !== newCallbacks.onLoad ||
+        prevCallbacks.onExit !== newCallbacks.onExit ||
+        prevCallbacks.onExitSuccess !== newCallbacks.onExitSuccess ||
+        prevCallbacks.onExitAbort !== newCallbacks.onExitAbort ||
+        prevCallbacks.onExitError !== newCallbacks.onExitError
+
+      if (callbacksChanged && prevConnectionId !== undefined) {
+        console.warn(
+          '[Quiltt] Callback functions changed after initial render. ' +
+            'This may cause unexpected behavior. Consider memoizing callback functions ' +
+            'to maintain stable references.'
+        )
+      }
+
+      prevCallbacks = { ...newCallbacks }
+    }
+  )
+
   // Create/update connector when needed
   const updateConnector = () => {
     const currentConnectorId = getConnectorId()
@@ -225,6 +273,7 @@ export const useQuilttConnector = (
       }
 
       connectorCreated = true
+      hasConnectorBeenCreated = true
       prevConnectionId = currentConnectionId
       prevConnectorId = currentConnectorId
       prevInstitution = currentInstitution

--- a/packages/vue/tests/components/QuilttButton.test.ts
+++ b/packages/vue/tests/components/QuilttButton.test.ts
@@ -1,4 +1,4 @@
-import { createApp, h } from 'vue'
+import { createApp, h, nextTick, ref } from 'vue'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -255,9 +255,11 @@ describe('QuilttButton', () => {
     app.unmount()
   })
 
-  it('generates remount key when forceRemountOnConnectionChange is enabled', () => {
+  it('recreates element when connectionId changes and forceRemountOnConnectionChange is enabled', async () => {
     const root = document.createElement('div')
     document.body.appendChild(root)
+
+    const connectionIdRef = ref('conn_123')
 
     const app = createApp({
       render: () =>
@@ -265,7 +267,7 @@ describe('QuilttButton', () => {
           QuilttButton,
           {
             connectorId: 'connector_test',
-            connectionId: 'conn_123',
+            connectionId: connectionIdRef.value,
             forceRemountOnConnectionChange: true,
           },
           () => 'Open'
@@ -274,15 +276,27 @@ describe('QuilttButton', () => {
 
     app.mount(root)
 
-    const button = root.querySelector('.quiltt-button')
-    expect(button).toBeTruthy()
+    const initialElement = root.querySelector('.quiltt-button')
+    expect(initialElement).toBeTruthy()
 
+    // Change connectionId to trigger a key change and complete replacement
+    connectionIdRef.value = 'conn_456'
+    await nextTick()
+
+    // The old element should have been destroyed and replaced by a new one
+    const currentElement = root.querySelector('.quiltt-button')
+    expect(currentElement).toBeTruthy()
+    expect(currentElement).not.toBe(initialElement)
+
+    // The composable is set up once at mount; the key is on the inner element,
+    // so setup() is not re-run — only the DOM element was replaced.
     const [connectorId, options] = mocks.useQuilttConnectorMock.mock.calls[0] as [
       () => string,
       Record<string, unknown>,
     ]
     expect(connectorId()).toBe('connector_test')
-    expect((options.connectionId as () => string | undefined)()).toBe('conn_123')
+    // The getter reflects the latest reactive value
+    expect((options.connectionId as () => string | undefined)()).toBe('conn_456')
 
     app.unmount()
   })

--- a/packages/vue/tests/components/QuilttButton.test.ts
+++ b/packages/vue/tests/components/QuilttButton.test.ts
@@ -212,4 +212,78 @@ describe('QuilttButton', () => {
 
     app.unmount()
   })
+
+  it('calls user-provided onClick handler when clicked', () => {
+    const onClick = vi.fn()
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp({
+      render: () => h(QuilttButton, { connectorId: 'connector_test', onClick }, () => 'Open'),
+    })
+
+    app.mount(root)
+
+    const button = root.querySelector('.quiltt-button') as HTMLButtonElement | null
+    button?.click()
+
+    expect(onClick).toHaveBeenCalled()
+    expect(mocks.openSpy).toHaveBeenCalledTimes(1)
+
+    app.unmount()
+  })
+
+  it('does not open connector when onClick prevents default', () => {
+    const onClick = vi.fn((event: MouseEvent) => event.preventDefault())
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp({
+      render: () => h(QuilttButton, { connectorId: 'connector_test', onClick }, () => 'Open'),
+    })
+
+    app.mount(root)
+
+    const button = root.querySelector('.quiltt-button') as HTMLButtonElement | null
+    button?.click()
+
+    expect(onClick).toHaveBeenCalled()
+    expect(mocks.openSpy).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+
+  it('generates remount key when forceRemountOnConnectionChange is enabled', () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp({
+      render: () =>
+        h(
+          QuilttButton,
+          {
+            connectorId: 'connector_test',
+            connectionId: 'conn_123',
+            forceRemountOnConnectionChange: true,
+          },
+          () => 'Open'
+        ),
+    })
+
+    app.mount(root)
+
+    const button = root.querySelector('.quiltt-button')
+    expect(button).toBeTruthy()
+
+    const [connectorId, options] = mocks.useQuilttConnectorMock.mock.calls[0] as [
+      () => string,
+      Record<string, unknown>,
+    ]
+    expect(connectorId()).toBe('connector_test')
+    expect((options.connectionId as () => string | undefined)()).toBe('conn_123')
+
+    app.unmount()
+  })
 })

--- a/packages/vue/tests/components/QuilttConnector.test.ts
+++ b/packages/vue/tests/components/QuilttConnector.test.ts
@@ -1,4 +1,4 @@
-import { createApp, h, ref } from 'vue'
+import { createApp, h, nextTick, ref } from 'vue'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -421,26 +421,36 @@ describe('QuilttConnector', () => {
     app.unmount()
   })
 
-  it('generates iframe key for forced remount when forceRemountOnConnectionChange is enabled', () => {
+  it('recreates iframe when connectionId changes and forceRemountOnConnectionChange is enabled', async () => {
     const root = document.createElement('div')
     document.body.appendChild(root)
+
+    const connectionIdRef = ref('conn_123')
 
     const app = createApp({
       render: () =>
         h(QuilttConnector, {
           connectorId: 'connector_test',
-          connectionId: 'conn_123',
+          connectionId: connectionIdRef.value,
           forceRemountOnConnectionChange: true,
         }),
     })
 
     app.mount(root)
 
-    const iframe = root.querySelector('iframe')
-    expect(iframe).toBeTruthy()
-    const src = iframe?.getAttribute('src') || ''
-    expect(src).toContain('connector_test.quiltt.app')
-    expect(src).toContain('connectionId=conn_123')
+    const initialIframe = root.querySelector('iframe')
+    expect(initialIframe).toBeTruthy()
+    expect(initialIframe?.getAttribute('src')).toContain('connectionId=conn_123')
+
+    // Change connectionId to trigger a key change and full iframe replacement
+    connectionIdRef.value = 'conn_456'
+    await nextTick()
+
+    // The old iframe should have been destroyed and replaced by a new one
+    const currentIframe = root.querySelector('iframe')
+    expect(currentIframe).toBeTruthy()
+    expect(currentIframe).not.toBe(initialIframe)
+    expect(currentIframe?.getAttribute('src')).toContain('connectionId=conn_456')
 
     app.unmount()
   })

--- a/packages/vue/tests/components/QuilttConnector.test.ts
+++ b/packages/vue/tests/components/QuilttConnector.test.ts
@@ -420,4 +420,28 @@ describe('QuilttConnector', () => {
 
     app.unmount()
   })
+
+  it('generates iframe key for forced remount when forceRemountOnConnectionChange is enabled', () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp({
+      render: () =>
+        h(QuilttConnector, {
+          connectorId: 'connector_test',
+          connectionId: 'conn_123',
+          forceRemountOnConnectionChange: true,
+        }),
+    })
+
+    app.mount(root)
+
+    const iframe = root.querySelector('iframe')
+    expect(iframe).toBeTruthy()
+    const src = iframe?.getAttribute('src') || ''
+    expect(src).toContain('connector_test.quiltt.app')
+    expect(src).toContain('connectionId=conn_123')
+
+    app.unmount()
+  })
 })

--- a/packages/vue/tests/components/QuilttContainer.test.ts
+++ b/packages/vue/tests/components/QuilttContainer.test.ts
@@ -212,4 +212,62 @@ describe('QuilttContainer', () => {
 
     app.unmount()
   })
+
+  it('wires onOpen callback when parent subscribes to open event', () => {
+    const onOpen = vi.fn()
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp({
+      render: () =>
+        h(QuilttContainer, {
+          connectorId: 'connector_test',
+          onOpen,
+        }),
+    })
+
+    app.mount(root)
+
+    const options = mocks.getLatestOptions()
+    expect(options).toBeDefined()
+    expect(options?.onOpen).toBeDefined()
+
+    const metadata = { connectorId: 'connector_test' }
+    ;(options?.onOpen as (metadata: unknown) => void)?.(metadata)
+
+    expect(onOpen).toHaveBeenCalledWith(metadata)
+
+    app.unmount()
+  })
+
+  it('generates remount key when forceRemountOnConnectionChange is enabled', () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp({
+      render: () =>
+        h(QuilttContainer, {
+          connectorId: 'connector_test',
+          connectionId: 'conn_123',
+          forceRemountOnConnectionChange: true,
+        }),
+    })
+
+    app.mount(root)
+
+    // The component should render without errors
+    const element = root.querySelector('.quiltt-container')
+    expect(element).toBeTruthy()
+
+    // Props are passed to the composable correctly
+    const [connectorId, options] = mocks.useQuilttConnectorMock.mock.calls[0] as [
+      () => string,
+      Record<string, unknown>,
+    ]
+    expect(connectorId()).toBe('connector_test')
+    expect((options.connectionId as () => string | undefined)()).toBe('conn_123')
+
+    app.unmount()
+  })
 })

--- a/packages/vue/tests/components/QuilttContainer.test.ts
+++ b/packages/vue/tests/components/QuilttContainer.test.ts
@@ -1,4 +1,4 @@
-import { createApp, h } from 'vue'
+import { createApp, h, nextTick, ref } from 'vue'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -241,32 +241,44 @@ describe('QuilttContainer', () => {
     app.unmount()
   })
 
-  it('generates remount key when forceRemountOnConnectionChange is enabled', () => {
+  it('recreates element when connectionId changes and forceRemountOnConnectionChange is enabled', async () => {
     const root = document.createElement('div')
     document.body.appendChild(root)
+
+    const connectionIdRef = ref('conn_123')
 
     const app = createApp({
       render: () =>
         h(QuilttContainer, {
           connectorId: 'connector_test',
-          connectionId: 'conn_123',
+          connectionId: connectionIdRef.value,
           forceRemountOnConnectionChange: true,
         }),
     })
 
     app.mount(root)
 
-    // The component should render without errors
-    const element = root.querySelector('.quiltt-container')
-    expect(element).toBeTruthy()
+    const initialElement = root.querySelector('.quiltt-container')
+    expect(initialElement).toBeTruthy()
 
-    // Props are passed to the composable correctly
+    // Change connectionId to trigger a key change and complete replacement
+    connectionIdRef.value = 'conn_456'
+    await nextTick()
+
+    // The old element should have been destroyed and replaced by a new one
+    const currentElement = root.querySelector('.quiltt-container')
+    expect(currentElement).toBeTruthy()
+    expect(currentElement).not.toBe(initialElement)
+
+    // The composable is set up once at mount; the key is on the inner element,
+    // so setup() is not re-run — only the DOM element was replaced.
     const [connectorId, options] = mocks.useQuilttConnectorMock.mock.calls[0] as [
       () => string,
       Record<string, unknown>,
     ]
     expect(connectorId()).toBe('connector_test')
-    expect((options.connectionId as () => string | undefined)()).toBe('conn_123')
+    // The getter reflects the latest reactive value
+    expect((options.connectionId as () => string | undefined)()).toBe('conn_456')
 
     app.unmount()
   })

--- a/packages/vue/tests/composables/useQuilttConnector.test.ts
+++ b/packages/vue/tests/composables/useQuilttConnector.test.ts
@@ -1,4 +1,4 @@
-import { createApp, nextTick, ref } from 'vue'
+import { createApp, nextTick, reactive, ref } from 'vue'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -356,5 +356,141 @@ describe('useQuilttConnector', () => {
 
     script?.remove()
     unmount()
+  })
+
+  it('rejects when an existing script tag triggers an error event', async () => {
+    const existingScript = document.createElement('script')
+    existingScript.src = `${cdnBase}/v1/connector.js`
+    document.head.appendChild(existingScript)
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { unmount } = mountComposable(() => useQuilttConnector('connector_test'))
+
+    await nextTick() // onMounted fires → loadScript → finds existing script → attaches listeners
+
+    existingScript.dispatchEvent(new Event('error'))
+    await nextTick()
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[Quiltt] Failed to load SDK:', expect.any(Error))
+
+    existingScript.remove()
+    unmount()
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('warns when callbacks change after connector has been created', async () => {
+    const connector = {
+      open: vi.fn(),
+      onEvent: vi.fn(),
+      onOpen: vi.fn(),
+      onLoad: vi.fn(),
+      onExit: vi.fn(),
+      onExitSuccess: vi.fn(),
+      onExitAbort: vi.fn(),
+      onExitError: vi.fn(),
+    }
+
+    ;(globalThis as any).Quiltt = {
+      authenticate: vi.fn(),
+      connect: vi.fn(() => connector),
+      reconnect: vi.fn(() => connector),
+    }
+
+    const options = reactive({
+      connectionId: 'conn_123',
+      onEvent: vi.fn(),
+    })
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { unmount } = mountComposable(() => useQuilttConnector('connector_test', options))
+
+    await nextTick()
+    await nextTick()
+    // Connector has been created, hasConnectorBeenCreated = true
+
+    // Change a callback — this triggers the callback change watcher
+    options.onEvent = vi.fn()
+    await nextTick()
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Callback functions changed after initial render')
+    )
+
+    unmount()
+    consoleWarnSpy.mockRestore()
+    delete (globalThis as any).Quiltt
+  })
+
+  it('skips callback change warning before connector has been created', async () => {
+    // Do NOT set globalThis.Quiltt so the SDK script is not loaded
+    // and the connector is never created (hasConnectorBeenCreated stays false)
+    const options = reactive({ onEvent: vi.fn() })
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { unmount } = mountComposable(() => useQuilttConnector('connector_test', options))
+
+    await nextTick()
+    // At this point: onMounted fired, loadScript created a script element,
+    // but isLoaded is false, so updateConnector did nothing.
+    // hasConnectorBeenCreated is still false.
+
+    // Change callbacks — the callback watcher fires but returns early
+    options.onEvent = vi.fn()
+    await nextTick()
+
+    // No warning logged (line 211 returns early since hasConnectorBeenCreated is false)
+    expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Callback functions changed')
+    )
+
+    // Clean up script tag
+    const script = document.head.querySelector(
+      `script[src^="${cdnBase}/v1/connector.js"]`
+    ) as HTMLScriptElement | null
+    script?.remove()
+    unmount()
+    consoleWarnSpy.mockRestore()
+  })
+
+  it('skips callback change warning when no connectionId is set', async () => {
+    const connector = {
+      open: vi.fn(),
+      onEvent: vi.fn(),
+      onOpen: vi.fn(),
+      onLoad: vi.fn(),
+      onExit: vi.fn(),
+      onExitSuccess: vi.fn(),
+      onExitAbort: vi.fn(),
+      onExitError: vi.fn(),
+    }
+
+    ;(globalThis as any).Quiltt = {
+      authenticate: vi.fn(),
+      connect: vi.fn(() => connector),
+      reconnect: vi.fn(() => connector),
+    }
+
+    const options = reactive({
+      onEvent: vi.fn(),
+    })
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { unmount } = mountComposable(() => useQuilttConnector('connector_test', options))
+
+    await nextTick()
+    await nextTick()
+
+    // Change a callback — but prevConnectionId is undefined, so no warning
+    options.onEvent = vi.fn()
+    await nextTick()
+
+    expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Callback functions changed after initial render')
+    )
+
+    unmount()
+    consoleWarnSpy.mockRestore()
+    delete (globalThis as any).Quiltt
   })
 })

--- a/scripts/check-deprecations.mjs
+++ b/scripts/check-deprecations.mjs
@@ -91,8 +91,12 @@ function isInsideJSDocBlock(lines, lineIndex) {
     const trimmed = lines[i].trim()
     if (inBlock) {
       if (trimmed.endsWith('*/')) inBlock = false
-    } else if (trimmed.startsWith('/**') && !trimmed.startsWith('/**/')) {
-      inBlock = true
+    } else if (trimmed.startsWith('/**')) {
+      // Single-line JSDoc (/** ... */): open and close on the same line,
+      // so don't enter block-tracking — avoids poisoning subsequent lines.
+      if (!trimmed.endsWith('*/')) {
+        inBlock = true
+      }
     }
   }
   return inBlock || lines[lineIndex].trim().startsWith('/**')

--- a/scripts/check-deprecations.mjs
+++ b/scripts/check-deprecations.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+/**
+ * check-deprecations.mjs
+ *
+ * Scans .changeset/*.md files for major version bumps. If any are found,
+ * scans the source tree for leftover @deprecated tags and deprecation
+ * console warnings, then reports them and exits non-zero.
+ *
+ * Usage:
+ *   node scripts/check-deprecations.mjs
+ */
+
+import { createReadStream } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { createInterface } from 'node:readline'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const CHANGESET_DIR = join(ROOT, '.changeset')
+const PACKAGES_DIR = join(ROOT, 'packages')
+
+// ---------------------------------------------------------------------------
+// Changeset parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the YAML frontmatter from a changeset .md file.
+ * Returns an array of package bump entries: [{ package: string, bump: string }]
+ */
+async function parseChangesetFile(filePath) {
+  const content = await readFile(filePath, 'utf-8')
+  const lines = content.split('\n')
+
+  // Changeset frontmatter is between the first pair of --- markers
+  if (lines[0]?.trim() !== '---') return []
+
+  const frontmatterLines = []
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') break
+    frontmatterLines.push(lines[i])
+  }
+
+  const entries = []
+  for (const line of frontmatterLines) {
+    // Format: "@quiltt/core": major   OR   "@quiltt/core": "major"
+    const match = line.match(/^"(@quiltt\/[^"]+)":\s*"?(\w+)"?/)
+    if (match) {
+      entries.push({ package: match[1], bump: match[2] })
+    }
+  }
+
+  return entries
+}
+
+/**
+ * Return true if any changeset in .changeset/ declares a major bump.
+ */
+async function hasMajorBump() {
+  let files
+  try {
+    files = await readdir(CHANGESET_DIR)
+  } catch {
+    return false
+  }
+
+  const changesetFiles = files.filter((f) => f.endsWith('.md') && f !== 'README.md')
+
+  for (const file of changesetFiles) {
+    const entries = await parseChangesetFile(join(CHANGESET_DIR, file))
+    if (entries.some((e) => e.bump === 'major')) {
+      return true
+    }
+  }
+
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Source scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a line is inside a JSDoc block comment (/** ... *​/)
+ * Very simple state-machine: track whether we're inside /**, end at *​/
+ */
+function isInsideJSDocBlock(lines, lineIndex) {
+  let inBlock = false
+  for (let i = 0; i <= lineIndex; i++) {
+    const trimmed = lines[i].trim()
+    if (inBlock) {
+      if (trimmed.endsWith('*/')) inBlock = false
+    } else if (trimmed.startsWith('/**') && !trimmed.startsWith('/**/')) {
+      inBlock = true
+    }
+  }
+  return inBlock || lines[lineIndex].trim().startsWith('/**')
+}
+
+/**
+ * Scan a single file for deprecation indicators.
+ * Returns an array of findings: [{ line, content }]
+ */
+async function scanSourceFile(filePath) {
+  const findings = []
+
+  const rl = createInterface({
+    input: createReadStream(filePath),
+    crlfDelay: Infinity,
+  })
+
+  const lines = []
+  for await (const line of rl) {
+    lines.push(line)
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const rawLine = lines[i]
+    const trimmed = rawLine.trim()
+    const lineNum = i + 1
+
+    // 1) @deprecated inside a JSDoc comment
+    if (trimmed.includes('@deprecated') && isInsideJSDocBlock(lines, i)) {
+      findings.push({ line: lineNum, content: rawLine, type: 'jsdoc' })
+      continue
+    }
+
+    // 2) console.warn with deprecation wording
+    const lower = trimmed.toLowerCase()
+    if (
+      lower.includes('console.warn(') &&
+      (lower.includes('deprecated') || lower.includes('deprecation'))
+    ) {
+      findings.push({ line: lineNum, content: rawLine, type: 'console-warn' })
+    }
+  }
+
+  return findings
+}
+
+/**
+ * Walk packages/ directories. Uses simple recursive descent,
+ * skipping build artifact directories.
+ */
+async function* walkSourceFiles(dir) {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      // Skip node_modules, dist, .next, etc.
+      if (['node_modules', 'dist', '.next', 'coverage', '__snapshots__'].includes(entry.name)) {
+        continue
+      }
+      yield* walkSourceFiles(fullPath)
+    } else if (/\.(ts|tsx|vue)$/.test(entry.name)) {
+      yield fullPath
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log(':: Check: Scanning .changeset/ for major version bumps...')
+  const major = await hasMajorBump()
+
+  if (!major) {
+    console.log(':: No major bumps detected. Skipping deprecation audit.')
+    process.exit(0)
+  }
+
+  console.log(':: Major bump detected! Auditing for leftover deprecations...\n')
+
+  const allFindings = []
+
+  for await (const filePath of walkSourceFiles(PACKAGES_DIR)) {
+    const relativePath = filePath.replace(ROOT, '').replace(/^\//, '')
+    const findings = await scanSourceFile(filePath)
+    for (const f of findings) {
+      allFindings.push({ file: relativePath, ...f })
+    }
+  }
+
+  if (allFindings.length === 0) {
+    console.log(':: No leftover deprecations found. Clean major bump!')
+    process.exit(0)
+  }
+
+  // Report findings
+  console.log(
+    `:: Found ${allFindings.length} deprecation(s) that must be resolved before a major release:\n`
+  )
+
+  for (const { file, line, content, type } of allFindings) {
+    const tag = type === 'jsdoc' ? '@deprecated' : 'console.warn'
+    console.log(`  ${file}:${line}  [${tag}]`)
+    console.log(`    ${content.trim()}`)
+    console.log()
+  }
+
+  console.log(':: Remove all deprecated code before cutting a major version.')
+  console.log(
+    ':: If a deprecation must remain, remove it from this major changeset and defer to a future major.'
+  )
+
+  process.exit(1)
+}
+
+main().catch((err) => {
+  console.error('Unexpected error:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Adds feature parity between the Vue and React packages with a new `QuilttContainer` component (deprecating `QuilttConnector`), a `useQuilttConnector` composable for programmatic connector management, `@click` event passthrough with `preventDefault()` support on `QuilttButton`, and a `forceRemountOnConnectionChange` prop across all connector components for clean connector state reset.

- [x] **Is commit history clean?**
  - Do all commit names start with verbs like `Add`, `Fix`, `Refactor`...?
  - Are all commits passing or marked with `[WIP]`?
- [x] **Are relevant documentation changes queued up?**
  - Are the Quiltt API Docs updated?
