### PR TITLE
Fix Flutter Release Job

### DIFF
--- a/.github/workflows/release-flutter.yml
+++ b/.github/workflows/release-flutter.yml
@@ -30,6 +30,17 @@ jobs:
         working-directory: packages/flutter
 
     steps:
+      - name: Validate ref is a flutter/v* tag
+        run: |
+          case "$GITHUB_REF" in
+            refs/tags/flutter/v*) ;;
+            *)
+              echo "ERROR: This workflow must run against a flutter/v* tag ref (got: $GITHUB_REF)"
+              echo "For workflow_dispatch, select a flutter/v* tag from the 'Use workflow from' dropdown."
+              exit 1
+              ;;
+          esac
+
       - name: Extract version from tag
         id: version
         env:

--- a/.github/workflows/release-flutter.yml
+++ b/.github/workflows/release-flutter.yml
@@ -7,6 +7,11 @@ on:
   push:
     tags:
       - "flutter/v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., 5.3.0)"
+        required: true
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -17,7 +22,6 @@ jobs:
   publish-flutter:
     name: Publish Flutter
     runs-on: ubuntu-latest
-    environment: pub-dev # pub-dev is a valid environment name on quiltt-sdks. If the GitHub Actions Workflow extension is flagging this as an error, it can be ignored.
     permissions:
       id-token: write
       contents: write
@@ -28,8 +32,14 @@ jobs:
     steps:
       - name: Extract version from tag
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${GITHUB_REF#refs/tags/flutter/v}"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${GITHUB_REF#refs/tags/flutter/v}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Releasing Flutter SDK v$VERSION"
 


### PR DESCRIPTION
## Summary
Remove GitHub `env` from Flutter release workflow

## Release Checklist

- [x] **Is commit history clean?**
  - Do all commit names start with verbs like `Add`, `Fix`, `Refactor`...?
  - Are all commits passing or marked with `[WIP]`?
- [x] **Are relevant documentation changes queued up?**
  - Are the Quiltt API Docs updated?
